### PR TITLE
QoL Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ck3tiger-for-vscode",
     "displayName": "ck3tiger for VS Code",
     "description": "Helps you make mods for Crusader Kings 3 using Amtep's Tiger tool (previously ck3-tiger)",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "icon": "images/logo.png",
     "engines": {
         "vscode": "^1.93.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ck3tiger-for-vscode",
     "displayName": "ck3tiger for VS Code",
     "description": "Helps you make mods for Crusader Kings 3 using Amtep's Tiger tool (previously ck3-tiger)",
-    "version": "1.1.3",
+    "version": "1.1.2",
     "icon": "images/logo.png",
     "engines": {
         "vscode": "^1.93.0"

--- a/package.json
+++ b/package.json
@@ -83,13 +83,13 @@
                     "description": "The location of a vanilla CK3 installation (like \"C:/Program Files (x86)/Steam/steamapps/common/Crusader Kings III/game\""
                 },
                 "ck3tiger.modPath": {
-                    "scope": "application",
+                    "scope": "workspace",
                     "type": "string",
                     "description": "The location of your .mod file (like \"Like Documents/Paradox Interactive/Crusader Kings III/mod/<.mod file>\""
                 },
                 "ck3tiger.minConfidence": {
                     "title": "Minimum confidence level",
-                    "scope": "application",
+                    "scope": "workspace",
                     "type": "string",
                     "enum": [
                         "weak",
@@ -106,14 +106,14 @@
                 },
                 "ck3tiger.experimental.runOnSave": {
                     "title": "Run ck3tiger on file save",
-                    "scope": "application",
+                    "scope": "workspace",
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "When enabled, automatically runs ck3tiger validation when a file is saved within the mod directory."
                 },
                 "ck3tiger.experimental.patterns": {
                     "title": "File patterns to detect changes",
-                    "scope": "application",
+                    "scope": "workspace",
                     "type": "string",
                     "default": "**/*.{txt,yml}",
                     "markdownDescription": "A glob pattern for files to run ck3tiger on when a file is saved within the mod directory."


### PR DESCRIPTION
Sets the `modPath` setting scope to `workspace` rather than `application`, along with a few other settings where that makes sense. Makes it a lot easier to use this extension with multiple mods, rather than having to pop into the settings menu each time you open a folder.